### PR TITLE
Fix key bindings on Gnome 3.4.1

### DIFF
--- a/shellshape/extension.js
+++ b/shellshape/extension.js
@@ -1,5 +1,6 @@
 // shellshape -- a tiling window manager extension for gnome-shell
 
+const Gio = imports.gi.Gio;
 const Lang = imports.lang;
 const Main = imports.ui.main;
 const Meta = imports.gi.Meta;
@@ -153,7 +154,7 @@ const Ext = function Ext() {
 	function handle(name, func) {
 		self._bound_keybindings[name] = true;
 		var added = self.current_display().add_keybinding(name,
-			KEYBINDING_BASE,
+			new Gio.Settings({ schema: KEYBINDING_BASE }),
 			Meta.KeyBindingFlags.NONE,
 			function() {
 				self._do(func, "handler for binding " + name);


### PR DESCRIPTION
add_keybinding now expect a GSettings object instead of a string, this fails to add the key bindings on Gnome 3.4.1, that fixed the problem for me, 

btw thanks for this awesome extension.
