### PR TITLE
gnome-shell 3.12 basic support

### DIFF
--- a/shellshape/metadata.json
+++ b/shellshape/metadata.json
@@ -1,5 +1,5 @@
 {
-  "shell-version": ["3.10"],
+  "shell-version": ["3.12"],
   "uuid": "shellshape@gfxmonk.net",
   "name": "shellshape",
   "description": "A tiling window extension for gnome-shell",

--- a/shellshape/workspace.js
+++ b/shellshape/workspace.js
@@ -292,7 +292,12 @@ Workspace.prototype = {
 				}
 				cb(win);
 			});
-			win.workspace_signals.push([actor, actor.connect(event_name + '-changed', signal_handler)]);
+            try{
+                win.workspace_signals.push([actor, actor.connect(event_name + '-changed', signal_handler)]);
+            } catch (e) {
+                win.workspace_signals.push([meta_window,
+                    meta_window.connect(event_name + '-changed', signal_handler)]);
+            }
 		});
 
 		bind_to_window_change('position', move_ops,     Lang.bind(this, this.on_window_moved, win));


### PR DESCRIPTION
In gnome-shell 3.12 the signals have been moved from MetaWindowActor to
MetaWindow.

With this patch shellshape is starting in gnome-shell 3.12 but still seems to
be unstable. Maybe the 3.12 development can be done in a working branch on
master side, so more people are able to test and fix bugs?

This is pull-request is related to #132 
