### PR TITLE
workaround for typescript 1.1 incompatibility

### DIFF
--- a/tools/tsc.gup
+++ b/tools/tsc.gup
@@ -4,7 +4,7 @@ tsc="../node_modules/typescript/bin/tsc"
 if [ ! -e "$tsc" ]; then
 	echo -e "$tsc not found\nInstalling TypeScript..." >&2
 	pushd .. >/dev/null
-	npm install typescript
+	npm install 'typescript@<1.1'
 	popd >/dev/null
 fi
 ln -s "$tsc" "$1"


### PR DESCRIPTION
the build tool currently installs the latest typescript version.
compilation with typescript 1.1 (released on oct 6) fails with to the following error:

```
$ tools/gup compile
gup  compile
gup    schemas/inputs
gup    shellshape/all
gup      shellshape/extension.js
gup        shellshape/_sources
../src/workspace.ts(434,10): error TS2365: Operator '===' cannot be applied to types 'Window' and 'Window'.
gup      Target `shellshape/extension.js` failed with exit status 1
gup    Target `shellshape/all` failed with exit status 2
gup  Target `compile` failed with exit status 2
```

this patch forces the installation of an older typescript version which works correctly
