### PR TITLE
Open `dconf-editor` to right path

### DIFF
--- a/shellshape/locale/de/LC_MESSAGES/shellshape.po
+++ b/shellshape/locale/de/LC_MESSAGES/shellshape.po
@@ -61,10 +61,6 @@ msgstr "Tastatureinstellungen bearbeiten"
 msgid "(make sure you have dconf-editor installed)"
 msgstr "(dconf-editor muss installiert sein)"
 
-#: prefs.js:192
-msgid "Navigate to"
-msgstr "Änderungen unter"
-
 #: prefs.js:204
 msgid "ERROR: Could not launch dconf-editor. Is it installed?"
 msgstr "FEHLER: dconf-editor konnte nicht geöffnet werden. Ist er installiert?"

--- a/shellshape/locale/fr/LC_MESSAGES/shellshape.po
+++ b/shellshape/locale/fr/LC_MESSAGES/shellshape.po
@@ -61,10 +61,6 @@ msgstr "Modifier les paramètres du clavier"
 msgid "(make sure you have dconf-editor installed)"
 msgstr "(assurez-vous que dconf-editor soit installé)"
 
-#: prefs.js:192
-msgid "Navigate to"
-msgstr "Naviguer vers"
-
 #: prefs.js:204
 msgid "ERROR: Could not launch dconf-editor. Is it installed?"
 msgstr "ERREUR : Impossible de lancer dconf-editor. Est-il installé ?"

--- a/shellshape/shellshape.pot
+++ b/shellshape/shellshape.pot
@@ -58,10 +58,6 @@ msgstr ""
 msgid "(make sure you have dconf-editor installed)"
 msgstr ""
 
-#: prefs.js:192
-msgid "Navigate to"
-msgstr ""
-
 #: prefs.js:204
 msgid "ERROR: Could not launch dconf-editor. Is it installed?"
 msgstr ""

--- a/src/gjs/prefs.ts
+++ b/src/gjs/prefs.ts
@@ -234,8 +234,8 @@ function buildPrefsWidget() {
 
 		var label = new Gtk.Label({
 			label: _("Edit keyboard settings") +
-				"\n<small>"+_("(make sure you have dconf-editor installed)")+"\n" +
-				_("Navigate to")+" org/gnome/shell/extensions/net/gfxmonk/shellshape</small>",
+				"\n<small>" + _("(make sure you have dconf &amp; dconf-editor installed)") +
+				"</small>",
 			use_markup: true});
 		var button = new Gtk.Button({
 			label: 'dconf-editor'
@@ -245,6 +245,9 @@ function buildPrefsWidget() {
 			try {
 				// The magic sauce that lets dconf-editor see our local schema:
 				var envp = ShellshapeSettings.envp_with_shellshape_xdg_data_dir();
+				GLib.spawn_sync(null,["dconf", "write",  "/ca/desrt/dconf-editor/saved-view",
+					"'/org/gnome/shell/extensions/net/gfxmonk/shellshape/keybindings/'"],
+					envp, GLib.SpawnFlags.SEARCH_PATH, null);
 				GLib.spawn_async(null, ['dconf-editor'], envp, GLib.SpawnFlags.SEARCH_PATH, null);
 			} catch(e) {
 				error_msg.set_label(_("ERROR: Could not launch dconf-editor. Is it installed?"));

--- a/src/gjs/prefs.ts
+++ b/src/gjs/prefs.ts
@@ -234,7 +234,7 @@ function buildPrefsWidget() {
 
 		var label = new Gtk.Label({
 			label: _("Edit keyboard settings") +
-				"\n<small>" + _("(make sure you have dconf &amp; dconf-editor installed)") +
+				"\n<small>" + _("(make sure you have dconf-editor installed)") +
 				"</small>",
 			use_markup: true});
 		var button = new Gtk.Button({
@@ -245,9 +245,7 @@ function buildPrefsWidget() {
 			try {
 				// The magic sauce that lets dconf-editor see our local schema:
 				var envp = ShellshapeSettings.envp_with_shellshape_xdg_data_dir();
-				GLib.spawn_sync(null,["dconf", "write",  "/ca/desrt/dconf-editor/saved-view",
-					"'/org/gnome/shell/extensions/net/gfxmonk/shellshape/keybindings/'"],
-					envp, GLib.SpawnFlags.SEARCH_PATH, null);
+				ShellshapeSettings.set_dconf_view();
 				GLib.spawn_async(null, ['dconf-editor'], envp, GLib.SpawnFlags.SEARCH_PATH, null);
 			} catch(e) {
 				error_msg.set_label(_("ERROR: Could not launch dconf-editor. Is it installed?"));

--- a/src/gjs/shellshape_settings.ts
+++ b/src/gjs/shellshape_settings.ts
@@ -14,6 +14,12 @@ module ShellshapeSettings {
 
 	var log = Logging.getLogger("shellshape.settings");
 
+	export function set_dconf_view() {
+		get_local_gsettings('ca.desrt.dconf-editor.Settings')
+			.set_string('saved-view',
+				'/'+KEYBINDINGS.replace(/\./g,'/')+'/');
+	}
+
 	export function envp_with_shellshape_xdg_data_dir() {
 		var xdg_data_base = Ext.dir.get_child('data');
 		if(!xdg_data_base.query_exists(null)) {


### PR DESCRIPTION
This adds a dependency on `dconf` as well as `dconf-editor`, but I think it's unlikely that anyone will install `dconf-editor` but be unable to install `dconf`.